### PR TITLE
Fix gcc compilation

### DIFF
--- a/tools/eval/eval.cpp
+++ b/tools/eval/eval.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 
 #include <xmmintrin.h>
+#include <pmmintrin.h>
 
 #include <math.h>
 


### PR DESCRIPTION
This line:  _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON)
requires pmmintrin.h in gcc