### PR TITLE
Avoid UB on completely misaligned pointers + improve alignment option…

### DIFF
--- a/tools/benchmark/benchmark.cpp
+++ b/tools/benchmark/benchmark.cpp
@@ -255,6 +255,11 @@ void RunBenchmark(const TBenchmarkOpts& opts) {
         std::cerr << "requirement alignment < 32 failed" << std::endl;
         exit(1);
     }
+    if (alignment % sizeof(T) != 0) {
+        std::cerr << "requirement on natural alignment failed: alignment should be multiple of " << sizeof(T) << std::endl;
+        exit(1);
+    }
+
     std::vector<T*> inVectors(nVectors);
     std::vector<T*> outVectors(nVectors);
     for (size_t i = 0; i < nVectors; ++i) {

--- a/tools/benchmark/opts_tclap.cpp
+++ b/tools/benchmark/opts_tclap.cpp
@@ -12,7 +12,7 @@ TBenchmarkOpts ParseOptions(int argc, char** argv) {
     cmd.add(nIterArg);
     TCLAP::ValueArg<size_t> vecSizeArg("", "size", "Vector size in elements, default 160", false, 160, "N");
     cmd.add(vecSizeArg);
-    TCLAP::ValueArg<size_t> alignmentArg("", "alignment", "Misalign values by Offset from 32 bit boundary, default 0", false, 0, "Offset");
+    TCLAP::ValueArg<size_t> alignmentArg("", "alignment", "Misalign values by Offset from 32 byte boundary (natural alignment required), default 0", false, 0, "Offset");
     cmd.add(alignmentArg);
     TCLAP::SwitchArg noDenormalsArg("", "nodenorm", "Do not honor denormals (faster)", cmd, false);
     TCLAP::SwitchArg useDoubleArg("", "double", "Use double precision, dafault is single precision", cmd, false);


### PR DESCRIPTION
The completely misaligned pointers e.g. float* not divisible by 4 are cannot be safely dereferenced by C++ standard (because they may only originate from pointer conversions from char* and accessing such pointer is UB under C++ type aliasing rules). So we leave ability to benchmark unaligned accesses in SIMD sense (not divisible by 16 or 32 depending on SIMD registers in use), but prohibit cases where alignment is worse than natural for type requested (4 for floats, 8 for doubles).