### PR TITLE
specify language standard for MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignoring build files
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,11 @@ set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/install)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
 
+# Specify the C++ 17 language standard for
+# any version of Microsoft Visual C++ Compiler
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
+endif()
+
 add_subdirectory(fastops)
 add_subdirectory(tools)


### PR DESCRIPTION
I added a specific flag for MSVC to enforce C++ 17 standards since I was getting these errors:

`[build] FastIntrinsics.h(47): error C2429: language feature 'terse static assert' requires compiler flag '/std:c++17'
[build] FastIntrinsics.h(112): error C7525: inline variables require at least '/std:c++17'
[build] FastIntrinsics.h(112): error C2127: 'NFastOps::NFastOpsDetail::constexpr_mm256_castsi256_ps': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(112): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_bb269d46282e52d2c49dfae927f71ca2>' is not a literal type
[build] FastIntrinsics.h(112): note: type 'NFastOps::NFastOpsDetail::<lambda_bb269d46282e52d2c49dfae927f71ca2>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor
[build] FastIntrinsics.h(113): error C7525: inline variables require at least '/std:c++17'
[build] FastIntrinsics.h(113): error C2127: 'NFastOps::NFastOpsDetail::constexpr_mm256_castps_si256': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(113): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_ffd0e14c71fc7615c54dd9a43d93c979>' is not a literal type
[build] FastIntrinsics.h(113): note: type 'NFastOps::NFastOpsDetail::<lambda_ffd0e14c71fc7615c54dd9a43d93c979>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor
[build] FastIntrinsics.h(114): error C7525: inline variables require at least '/std:c++17'
[build] FastIntrinsics.h(114): error C2127: 'NFastOps::NFastOpsDetail::constexpr_mm256_castsi256_pd': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(114): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_1e6730597ebbadf8d7e0ae388ca0da80>' is not a literal type
[build] FastIntrinsics.h(114): note: type 'NFastOps::NFastOpsDetail::<lambda_1e6730597ebbadf8d7e0ae388ca0da80>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor
[build] FastIntrinsics.h(115): error C7525: inline variables require at least '/std:c++17'
[build] FastIntrinsics.h(115): error C2127: 'NFastOps::NFastOpsDetail::constexpr_mm256_castpd_si256': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(115): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_567c6220412c4b61d1e6b74a1f9f6e7b>' is not a literal type
[build] FastIntrinsics.h(115): note: type 'NFastOps::NFastOpsDetail::<lambda_567c6220412c4b61d1e6b74a1f9f6e7b>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor
[build] FastIntrinsics.h(124): error C2127: 'CastSi': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(112): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_bb269d46282e52d2c49dfae927f71ca2>' is not a literal type
[build] FastIntrinsics.h(112): note: type 'NFastOps::NFastOpsDetail::<lambda_bb269d46282e52d2c49dfae927f71ca2>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor
[build] FastIntrinsics.h(125): error C2127: 'CastPf': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(113): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_ffd0e14c71fc7615c54dd9a43d93c979>' is not a literal type
[build] FastIntrinsics.h(113): note: type 'NFastOps::NFastOpsDetail::<lambda_ffd0e14c71fc7615c54dd9a43d93c979>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor
[build] FastIntrinsics.h(186): error C2127: 'CastSi': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(114): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_1e6730597ebbadf8d7e0ae388ca0da80>' is not a literal type
[build] FastIntrinsics.h(114): note: type 'NFastOps::NFastOpsDetail::<lambda_1e6730597ebbadf8d7e0ae388ca0da80>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor
[build] FastIntrinsics.h(187): error C2127: 'CastPf': illegal initialization of 'constexpr' entity with a non-constant expression
[build] FastIntrinsics.h(115): note: failure was because type 'NFastOps::NFastOpsDetail::<lambda_567c6220412c4b61d1e6b74a1f9f6e7b>' is not a literal type
[build] FastIntrinsics.h(115): note: type 'NFastOps::NFastOpsDetail::<lambda_567c6220412c4b61d1e6b74a1f9f6e7b>' is not a literal type because it is not an aggregate type, a closure type, or does not have a constexpr constructor that is not a copy or move constructor`